### PR TITLE
Use async scheduling for broadcast receivers

### DIFF
--- a/app/src/main/java/de/moosfett/notificationbundler/receivers/BootCompletedReceiver.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/receivers/BootCompletedReceiver.kt
@@ -5,21 +5,31 @@ import android.content.Context
 import android.content.Intent
 import de.moosfett.notificationbundler.settings.SettingsStore
 import de.moosfett.notificationbundler.work.Scheduling
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 import java.time.ZoneId
 import java.time.ZonedDateTime
 
 class BootCompletedReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         if (intent.action == Intent.ACTION_BOOT_COMPLETED) {
-            runBlocking {
-                val settings = SettingsStore(context)
-                val times = settings.getTimes()
-                val now = ZonedDateTime.now(ZoneId.systemDefault())
-                val next = Scheduling.nextRun(now, times)
-                val delay = next.toInstant().toEpochMilli() - System.currentTimeMillis()
-                Scheduling.enqueueOnce(context, delay)
-            }
+            val pendingResult = goAsync()
+            val scope = CoroutineScope(Dispatchers.Default)
+            scope.launch {
+                try {
+                    val settings = SettingsStore(context)
+                    val times = settings.getTimes()
+                    val now = ZonedDateTime.now(ZoneId.systemDefault())
+                    val next = Scheduling.nextRun(now, times)
+                    val delay =
+                        next.toInstant().toEpochMilli() - System.currentTimeMillis()
+                    Scheduling.enqueueOnce(context, delay)
+                } finally {
+                    pendingResult.finish()
+                }
+            }.invokeOnCompletion { scope.cancel() }
         }
     }
 }

--- a/app/src/main/java/de/moosfett/notificationbundler/receivers/TimezoneChangedReceiver.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/receivers/TimezoneChangedReceiver.kt
@@ -5,21 +5,31 @@ import android.content.Context
 import android.content.Intent
 import de.moosfett.notificationbundler.settings.SettingsStore
 import de.moosfett.notificationbundler.work.Scheduling
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 import java.time.ZoneId
 import java.time.ZonedDateTime
 
 class TimezoneChangedReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         if (intent.action == Intent.ACTION_TIMEZONE_CHANGED) {
-            runBlocking {
-                val settings = SettingsStore(context)
-                val times = settings.getTimes()
-                val now = ZonedDateTime.now(ZoneId.systemDefault())
-                val next = Scheduling.nextRun(now, times)
-                val delay = next.toInstant().toEpochMilli() - System.currentTimeMillis()
-                Scheduling.enqueueOnce(context, delay)
-            }
+            val pendingResult = goAsync()
+            val scope = CoroutineScope(Dispatchers.Default)
+            scope.launch {
+                try {
+                    val settings = SettingsStore(context)
+                    val times = settings.getTimes()
+                    val now = ZonedDateTime.now(ZoneId.systemDefault())
+                    val next = Scheduling.nextRun(now, times)
+                    val delay =
+                        next.toInstant().toEpochMilli() - System.currentTimeMillis()
+                    Scheduling.enqueueOnce(context, delay)
+                } finally {
+                    pendingResult.finish()
+                }
+            }.invokeOnCompletion { scope.cancel() }
         }
     }
 }

--- a/app/src/main/java/de/moosfett/notificationbundler/work/DeliveryWorker.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/work/DeliveryWorker.kt
@@ -6,7 +6,6 @@ import androidx.work.WorkerParameters
 import de.moosfett.notificationbundler.data.repo.NotificationsRepository
 import de.moosfett.notificationbundler.notifications.Notifier
 import de.moosfett.notificationbundler.settings.SettingsStore
-import kotlinx.coroutines.runBlocking
 import java.time.ZoneId
 import java.time.ZonedDateTime
 
@@ -42,13 +41,11 @@ class DeliveryWorker(appContext: Context, params: WorkerParameters): CoroutineWo
         return Result.success()
     }
 
-    private fun rescheduleNext() {
-        runBlocking {
-            val times = settings.getTimes()
-            val now = ZonedDateTime.now(ZoneId.systemDefault())
-            val next = Scheduling.nextRun(now, times)
-            val delay = next.toInstant().toEpochMilli() - System.currentTimeMillis()
-            Scheduling.enqueueOnce(applicationContext, delay)
-        }
+    private suspend fun rescheduleNext() {
+        val times = settings.getTimes()
+        val now = ZonedDateTime.now(ZoneId.systemDefault())
+        val next = Scheduling.nextRun(now, times)
+        val delay = next.toInstant().toEpochMilli() - System.currentTimeMillis()
+        Scheduling.enqueueOnce(applicationContext, delay)
     }
 }


### PR DESCRIPTION
## Summary
- Replace blocking scheduling in BootCompletedReceiver and TimezoneChangedReceiver with goAsync coroutines
- Make DeliveryWorker.rescheduleNext suspend and invoke directly from doWork

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb8089b508329b40fb192d3123ce3