### PR TITLE
Add indices and Room migration for notifications

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -88,6 +88,7 @@ dependencies {
 
   // Testing
   testImplementation("junit:junit:4.13.2")
+  testImplementation("org.mockito:mockito-core:5.11.0")
   androidTestImplementation("androidx.test.ext:junit:1.2.1")
   androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
   androidTestImplementation(platform("androidx.compose:compose-bom:2024.06.00"))

--- a/app/src/main/java/de/moosfett/notificationbundler/data/db/AppDatabase.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/data/db/AppDatabase.kt
@@ -4,12 +4,14 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import de.moosfett.notificationbundler.data.entity.FilterRuleEntity
 import de.moosfett.notificationbundler.data.entity.NotificationEntity
 
 @Database(
     entities = [NotificationEntity::class, FilterRuleEntity::class],
-    version = 1
+    version = 2
 )
 abstract class AppDatabase : RoomDatabase() {
     abstract fun notifications(): NotificationDao
@@ -18,13 +20,24 @@ abstract class AppDatabase : RoomDatabase() {
     companion object {
         @Volatile private var INSTANCE: AppDatabase? = null
 
+        val MIGRATION_1_2 = object : Migration(1, 2) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS index_notifications_postTime ON notifications(postTime)"
+                )
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS index_notifications_packageName ON notifications(packageName)"
+                )
+            }
+        }
+
         fun getInstance(context: Context): AppDatabase =
             INSTANCE ?: synchronized(this) {
                 INSTANCE ?: Room.databaseBuilder(
                     context.applicationContext,
                     AppDatabase::class.java,
                     "nb.db"
-                ).fallbackToDestructiveMigration().build().also { INSTANCE = it }
+                ).addMigrations(MIGRATION_1_2).build().also { INSTANCE = it }
             }
     }
 }

--- a/app/src/main/java/de/moosfett/notificationbundler/data/entity/NotificationEntity.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/data/entity/NotificationEntity.kt
@@ -1,9 +1,13 @@
 package de.moosfett.notificationbundler.data.entity
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "notifications")
+@Entity(
+    tableName = "notifications",
+    indices = [Index("postTime"), Index("packageName")]
+)
 data class NotificationEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,
     val key: String?,

--- a/app/src/test/java/de/moosfett/notificationbundler/data/db/MigrationTest.kt
+++ b/app/src/test/java/de/moosfett/notificationbundler/data/db/MigrationTest.kt
@@ -1,0 +1,16 @@
+package de.moosfett.notificationbundler.data.db
+
+import androidx.sqlite.db.SupportSQLiteDatabase
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+
+class MigrationTest {
+    @Test
+    fun addsIndices() {
+        val db = mock(SupportSQLiteDatabase::class.java)
+        AppDatabase.MIGRATION_1_2.migrate(db)
+        verify(db).execSQL("CREATE INDEX IF NOT EXISTS index_notifications_postTime ON notifications(postTime)")
+        verify(db).execSQL("CREATE INDEX IF NOT EXISTS index_notifications_packageName ON notifications(packageName)")
+    }
+}


### PR DESCRIPTION
## Summary
- add indices on `postTime` and `packageName` to `NotificationEntity`
- bump Room DB version to 2 with migration creating indices
- test migration executes index creation

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb8fd97c08329a49c65acf20d0e64