### PR TITLE
Add notification listener permission prompt

### DIFF
--- a/app/src/main/java/de/moosfett/notificationbundler/ui/screens/DashboardScreen.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/ui/screens/DashboardScreen.kt
@@ -1,23 +1,50 @@
 package de.moosfett.notificationbundler.ui.screens
 
+import android.content.Intent
+import android.provider.Settings
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.res.stringResource
+import androidx.core.app.NotificationManagerCompat
 import de.moosfett.notificationbundler.R
 
 @Composable
 fun DashboardScreen() {
-    Column(
-        modifier = Modifier.fillMaxSize().padding(16.dp),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Text(text = stringResource(id = R.string.dashboard), style = MaterialTheme.typography.headlineSmall)
-        Spacer(Modifier.height(12.dp))
-        Text("This screen is intentionally minimal. Add logic and state later.")
+    val context = LocalContext.current
+    val isEnabled = NotificationManagerCompat.getEnabledListenerPackages(context)
+        .contains(context.packageName)
+
+    if (!isEnabled) {
+        Column(
+            modifier = Modifier.fillMaxSize().padding(16.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(text = stringResource(id = R.string.listener_not_enabled))
+            Spacer(Modifier.height(12.dp))
+            Button(onClick = {
+                context.startActivity(Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS))
+            }) {
+                Text(text = stringResource(id = R.string.open_settings))
+            }
+        }
+    } else {
+        Column(
+            modifier = Modifier.fillMaxSize().padding(16.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = stringResource(id = R.string.dashboard),
+                style = MaterialTheme.typography.headlineSmall
+            )
+            Spacer(Modifier.height(12.dp))
+            Text("This screen is intentionally minimal. Add logic and state later.")
+        }
     }
 }


### PR DESCRIPTION
## Summary
- check notification listener access on dashboard screen
- prompt user to enable access and open system settings if disabled

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdba4b7a8483299797fd3e28bbe2ac