### PR TITLE
Add notification action buttons and receiver tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -89,6 +89,7 @@ dependencies {
   // Testing
   testImplementation("junit:junit:4.13.2")
   testImplementation("org.mockito:mockito-core:5.11.0")
+  testImplementation("org.mockito:mockito-inline:5.11.0")
   androidTestImplementation("androidx.test.ext:junit:1.2.1")
   androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
   androidTestImplementation(platform("androidx.compose:compose-bom:2024.06.00"))

--- a/app/src/main/java/de/moosfett/notificationbundler/notifications/Notifier.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/notifications/Notifier.kt
@@ -10,6 +10,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import de.moosfett.notificationbundler.R
 import de.moosfett.notificationbundler.ui.MainActivity
+import de.moosfett.notificationbundler.receivers.DeliveryActionReceiver
 
 object Notifier {
 
@@ -49,6 +50,22 @@ object Notifier {
             context, 0, Intent(context, MainActivity::class.java),
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
+
+        val deliverNow = PendingIntent.getBroadcast(
+            context, 1,
+            Intent(context, DeliveryActionReceiver::class.java).setAction(DeliveryActionReceiver.ACTION_DELIVER_NOW),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        val snooze15m = PendingIntent.getBroadcast(
+            context, 2,
+            Intent(context, DeliveryActionReceiver::class.java).setAction(DeliveryActionReceiver.ACTION_SNOOZE_15M),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        val skip = PendingIntent.getBroadcast(
+            context, 3,
+            Intent(context, DeliveryActionReceiver::class.java).setAction(DeliveryActionReceiver.ACTION_SKIP),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
         val inbox = NotificationCompat.InboxStyle()
         lines.take(7).forEach { inbox.addLine(it) }
         val n = NotificationCompat.Builder(context, CH_BUNDLED)
@@ -58,6 +75,21 @@ object Notifier {
             .setStyle(inbox)
             .setContentIntent(pi)
             .setAutoCancel(true)
+            .addAction(
+                android.R.drawable.ic_media_play,
+                context.getString(R.string.deliver_now),
+                deliverNow
+            )
+            .addAction(
+                android.R.drawable.ic_lock_idle_alarm,
+                context.getString(R.string.snooze_15m),
+                snooze15m
+            )
+            .addAction(
+                android.R.drawable.ic_menu_close_clear_cancel,
+                context.getString(R.string.skip),
+                skip
+            )
             .build()
         val id = 1010
         NotificationManagerCompat.from(context).notify(id, n)

--- a/app/src/test/java/de/moosfett/notificationbundler/receivers/DeliveryActionReceiverTest.kt
+++ b/app/src/test/java/de/moosfett/notificationbundler/receivers/DeliveryActionReceiverTest.kt
@@ -1,0 +1,52 @@
+package de.moosfett.notificationbundler.receivers
+
+import android.content.Context
+import android.content.Intent
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequest
+import androidx.work.WorkManager
+import de.moosfett.notificationbundler.work.Scheduling
+import org.junit.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mockito
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+
+class DeliveryActionReceiverTest {
+    private val receiver = DeliveryActionReceiver()
+
+    @Test
+    fun `deliver now enqueues work`() {
+        val context = mock(Context::class.java)
+        val wm = mock(WorkManager::class.java)
+        Mockito.mockStatic(WorkManager::class.java).use { wmStatic ->
+            wmStatic.`when`<WorkManager> { WorkManager.getInstance(context) }.thenReturn(wm)
+
+            receiver.onReceive(context, Intent(DeliveryActionReceiver.ACTION_DELIVER_NOW))
+
+            verify(wm).enqueueUniqueWork(eq("delivery"), eq(ExistingWorkPolicy.KEEP), any(OneTimeWorkRequest::class.java))
+        }
+    }
+
+    @Test
+    fun `snooze 15m schedules delayed work`() {
+        val context = mock(Context::class.java)
+        Mockito.mockStatic(Scheduling::class.java).use { schedStatic ->
+            receiver.onReceive(context, Intent(DeliveryActionReceiver.ACTION_SNOOZE_15M))
+            schedStatic.verify { Scheduling.enqueueOnce(context, 15L * 60L * 1000L) }
+        }
+    }
+
+    @Test
+    fun `skip does nothing`() {
+        val context = mock(Context::class.java)
+        Mockito.mockStatic(WorkManager::class.java).use { wmStatic ->
+            Mockito.mockStatic(Scheduling::class.java).use { schedStatic ->
+                receiver.onReceive(context, Intent(DeliveryActionReceiver.ACTION_SKIP))
+                wmStatic.verifyNoInteractions()
+                schedStatic.verifyNoInteractions()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add deliver, snooze, and skip actions to bundled summary notifications
- test DeliveryActionReceiver for deliver now, snooze 15m, and skip

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbda85df08329bbbdb1e9ff630491