### PR TITLE
chore: remove unused duration imports

### DIFF
--- a/app/src/main/java/de/moosfett/notificationbundler/work/Scheduling.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/work/Scheduling.kt
@@ -6,8 +6,6 @@ import androidx.work.await
 import java.time.*
 import java.time.format.DateTimeFormatter
 import java.util.concurrent.TimeUnit
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
 
 object Scheduling {
     private const val TAG = "delivery"


### PR DESCRIPTION
## Summary
- clean up Scheduling by removing unused `kotlin.time.Duration` imports

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc22e836483299a434d4d55a2c330