### PR TITLE
chore: remove unused Flow import from FiltersDao

### DIFF
--- a/app/src/main/java/de/moosfett/notificationbundler/data/db/FiltersDao.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/data/db/FiltersDao.kt
@@ -2,7 +2,6 @@ package de.moosfett.notificationbundler.data.db
 
 import androidx.room.*
 import de.moosfett.notificationbundler.data.entity.FilterRuleEntity
-import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface FiltersDao {


### PR DESCRIPTION
## Summary
- remove leftover Flow import from FiltersDao DAO

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc2f0e31c8329901a0fe6bf43a572