### PR TITLE
Clamp receiver delays to non-negative

### DIFF
--- a/app/src/main/java/de/moosfett/notificationbundler/receivers/BootCompletedReceiver.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/receivers/BootCompletedReceiver.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import java.time.ZoneId
 import java.time.ZonedDateTime
+import kotlin.math.max
 
 class BootCompletedReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
@@ -24,7 +25,7 @@ class BootCompletedReceiver : BroadcastReceiver() {
                     val now = ZonedDateTime.now(ZoneId.systemDefault())
                     val next = Scheduling.nextRun(now, times)
                     val delay =
-                        next.toInstant().toEpochMilli() - System.currentTimeMillis()
+                        max(0L, next.toInstant().toEpochMilli() - System.currentTimeMillis())
                     Scheduling.enqueueOnce(context, delay)
                 } finally {
                     pendingResult.finish()

--- a/app/src/main/java/de/moosfett/notificationbundler/receivers/DeliveryActionReceiver.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/receivers/DeliveryActionReceiver.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import kotlin.math.max
 
 class DeliveryActionReceiver : BroadcastReceiver() {
 
@@ -30,7 +31,8 @@ class DeliveryActionReceiver : BroadcastReceiver() {
                 val scope = CoroutineScope(Dispatchers.Default)
                 scope.launch {
                     try {
-                        Scheduling.enqueueOnce(context, 15L * 60L * 1000L)
+                        val delay = max(0L, 15L * 60L * 1000L)
+                        Scheduling.enqueueOnce(context, delay)
                     } finally {
                         pendingResult.finish()
                     }

--- a/app/src/main/java/de/moosfett/notificationbundler/receivers/TimezoneChangedReceiver.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/receivers/TimezoneChangedReceiver.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import java.time.ZoneId
 import java.time.ZonedDateTime
+import kotlin.math.max
 
 class TimezoneChangedReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
@@ -24,7 +25,7 @@ class TimezoneChangedReceiver : BroadcastReceiver() {
                     val now = ZonedDateTime.now(ZoneId.systemDefault())
                     val next = Scheduling.nextRun(now, times)
                     val delay =
-                        next.toInstant().toEpochMilli() - System.currentTimeMillis()
+                        max(0L, next.toInstant().toEpochMilli() - System.currentTimeMillis())
                     Scheduling.enqueueOnce(context, delay)
                 } finally {
                     pendingResult.finish()


### PR DESCRIPTION
## Summary
- Clamp delay to at least 0 before scheduling in BootCompletedReceiver
- Apply same delay clamping in TimezoneChangedReceiver
- Sanitize snooze delay in DeliveryActionReceiver

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc4cbc8e483298552ccc1fc421526