### PR TITLE
Refactor scheduling in receivers

### DIFF
--- a/app/src/main/java/de/moosfett/notificationbundler/receivers/BootCompletedReceiver.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/receivers/BootCompletedReceiver.kt
@@ -3,15 +3,10 @@ package de.moosfett.notificationbundler.receivers
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import de.moosfett.notificationbundler.settings.SettingsStore
-import de.moosfett.notificationbundler.work.Scheduling
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import java.time.ZoneId
-import java.time.ZonedDateTime
-import kotlin.math.max
 
 class BootCompletedReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
@@ -20,13 +15,7 @@ class BootCompletedReceiver : BroadcastReceiver() {
             val scope = CoroutineScope(Dispatchers.Default)
             scope.launch {
                 try {
-                    val settings = SettingsStore(context)
-                    val times = settings.getTimes()
-                    val now = ZonedDateTime.now(ZoneId.systemDefault())
-                    val next = Scheduling.nextRun(now, times)
-                    val delay =
-                        max(0L, next.toInstant().toEpochMilli() - System.currentTimeMillis())
-                    Scheduling.enqueueOnce(context, delay)
+                    scheduleNextDelivery(context)
                 } finally {
                     pendingResult.finish()
                 }

--- a/app/src/main/java/de/moosfett/notificationbundler/receivers/Receivers.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/receivers/Receivers.kt
@@ -1,0 +1,20 @@
+package de.moosfett.notificationbundler.receivers
+
+import android.content.Context
+import de.moosfett.notificationbundler.settings.SettingsStore
+import de.moosfett.notificationbundler.work.Scheduling
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import kotlin.math.max
+
+/**
+ * Helper functions for broadcast receivers.
+ */
+suspend fun scheduleNextDelivery(context: Context) {
+    val settings = SettingsStore(context)
+    val times = settings.getTimes()
+    val now = ZonedDateTime.now(ZoneId.systemDefault())
+    val next = Scheduling.nextRun(now, times)
+    val delay = max(0L, next.toInstant().toEpochMilli() - System.currentTimeMillis())
+    Scheduling.enqueueOnce(context, delay)
+}

--- a/app/src/main/java/de/moosfett/notificationbundler/receivers/TimezoneChangedReceiver.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/receivers/TimezoneChangedReceiver.kt
@@ -3,15 +3,10 @@ package de.moosfett.notificationbundler.receivers
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import de.moosfett.notificationbundler.settings.SettingsStore
-import de.moosfett.notificationbundler.work.Scheduling
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import java.time.ZoneId
-import java.time.ZonedDateTime
-import kotlin.math.max
 
 class TimezoneChangedReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
@@ -20,13 +15,7 @@ class TimezoneChangedReceiver : BroadcastReceiver() {
             val scope = CoroutineScope(Dispatchers.Default)
             scope.launch {
                 try {
-                    val settings = SettingsStore(context)
-                    val times = settings.getTimes()
-                    val now = ZonedDateTime.now(ZoneId.systemDefault())
-                    val next = Scheduling.nextRun(now, times)
-                    val delay =
-                        max(0L, next.toInstant().toEpochMilli() - System.currentTimeMillis())
-                    Scheduling.enqueueOnce(context, delay)
+                    scheduleNextDelivery(context)
                 } finally {
                     pendingResult.finish()
                 }


### PR DESCRIPTION
## Summary
- extract `scheduleNextDelivery` helper to compute next delivery time and enqueue work
- invoke new helper from `BootCompletedReceiver` and `TimezoneChangedReceiver`

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc8914e108329989ad9fc04149b6b