### PR TITLE
Simplify snooze delay calculation

### DIFF
--- a/app/src/main/java/de/moosfett/notificationbundler/receivers/DeliveryActionReceiver.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/receivers/DeliveryActionReceiver.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import kotlin.math.max
 
 class DeliveryActionReceiver : BroadcastReceiver() {
 
@@ -31,7 +30,7 @@ class DeliveryActionReceiver : BroadcastReceiver() {
                 val scope = CoroutineScope(Dispatchers.Default)
                 scope.launch {
                     try {
-                        val delay = max(0L, 15L * 60L * 1000L)
+                        val delay = 15 * 60 * 1000L
                         Scheduling.enqueueOnce(context, delay)
                     } finally {
                         pendingResult.finish()


### PR DESCRIPTION
## Summary
- Replace `max` call with constant delay value in `DeliveryActionReceiver`
- Remove unused `kotlin.math.max` import

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc9bc266883299c5ec9b6983d2fa8