### PR TITLE
Cache filter rules in notification service

### DIFF
--- a/app/src/main/java/de/moosfett/notificationbundler/data/db/FiltersDao.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/data/db/FiltersDao.kt
@@ -2,11 +2,15 @@ package de.moosfett.notificationbundler.data.db
 
 import androidx.room.*
 import de.moosfett.notificationbundler.data.entity.FilterRuleEntity
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface FiltersDao {
     @Query("SELECT * FROM filter_rules")
     suspend fun all(): List<FilterRuleEntity>
+
+    @Query("SELECT * FROM filter_rules")
+    fun observeAll(): Flow<List<FilterRuleEntity>>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsert(rule: FilterRuleEntity): Long

--- a/app/src/main/java/de/moosfett/notificationbundler/data/repo/FiltersRepository.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/data/repo/FiltersRepository.kt
@@ -3,11 +3,14 @@ package de.moosfett.notificationbundler.data.repo
 import android.content.Context
 import de.moosfett.notificationbundler.data.db.AppDatabase
 import de.moosfett.notificationbundler.data.entity.FilterRuleEntity
+import kotlinx.coroutines.flow.Flow
 
 class FiltersRepository(private val appContext: Context) {
     private val db by lazy { AppDatabase.getInstance(appContext) }
 
     suspend fun all(): List<FilterRuleEntity> = db.filters().all()
+
+    fun observeAll(): Flow<List<FilterRuleEntity>> = db.filters().observeAll()
 
     suspend fun upsert(rule: FilterRuleEntity) = db.filters().upsert(rule)
 


### PR DESCRIPTION
## Summary
- Cache filter rules inside `NotificationCollectorService` using `StateFlow`
- Observe repository changes to keep cached rules up to date
- Use cached rules instead of reloading from DB for each notification

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcb5ef9e08329bea8fdd6605311b6