### PR TITLE
Refactor DeliveryActionReceiver test to use coroutine scheduler

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,6 +90,7 @@ dependencies {
   testImplementation("junit:junit:4.13.2")
   testImplementation("org.mockito:mockito-core:5.11.0")
   testImplementation("org.mockito:mockito-inline:5.11.0")
+  testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
   testImplementation("org.robolectric:robolectric:4.11.1")
   androidTestImplementation("androidx.test.ext:junit:1.2.1")
   androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")

--- a/app/src/main/java/de/moosfett/notificationbundler/receivers/DeliveryActionReceiver.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/receivers/DeliveryActionReceiver.kt
@@ -6,12 +6,16 @@ import android.content.Intent
 import androidx.work.*
 import de.moosfett.notificationbundler.work.DeliveryWorker
 import de.moosfett.notificationbundler.work.Scheduling
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import kotlin.jvm.JvmOverloads
 
-class DeliveryActionReceiver : BroadcastReceiver() {
+class DeliveryActionReceiver @JvmOverloads constructor(
+    private val dispatcher: CoroutineDispatcher = Dispatchers.Default,
+) : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
         when (intent.action) {
@@ -27,7 +31,7 @@ class DeliveryActionReceiver : BroadcastReceiver() {
             ACTION_SNOOZE_15M -> {
                 // Replace any existing with a new one in 15m
                 val pendingResult = goAsync()
-                val scope = CoroutineScope(Dispatchers.Default)
+                val scope = CoroutineScope(dispatcher)
                 scope.launch {
                     try {
                         val delay = 15 * 60 * 1000L

--- a/app/src/test/java/de/moosfett/notificationbundler/receivers/DeliveryActionReceiverTest.kt
+++ b/app/src/test/java/de/moosfett/notificationbundler/receivers/DeliveryActionReceiverTest.kt
@@ -6,7 +6,11 @@ import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
 import de.moosfett.notificationbundler.work.Scheduling
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.Test
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.eq
@@ -14,11 +18,12 @@ import org.mockito.Mockito
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class DeliveryActionReceiverTest {
-    private val receiver = DeliveryActionReceiver()
 
     @Test
     fun `deliver now enqueues work`() {
+        val receiver = DeliveryActionReceiver()
         val context = mock(Context::class.java)
         val wm = mock(WorkManager::class.java)
         Mockito.mockStatic(WorkManager::class.java).use { wmStatic ->
@@ -31,17 +36,21 @@ class DeliveryActionReceiverTest {
     }
 
     @Test
-    fun `snooze 15m schedules delayed work`() {
+    fun `snooze 15m schedules delayed work`() = runBlocking {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        val receiver = DeliveryActionReceiver(dispatcher)
         val context = mock(Context::class.java)
         Mockito.mockStatic(Scheduling::class.java).use { schedStatic ->
             receiver.onReceive(context, Intent(DeliveryActionReceiver.ACTION_SNOOZE_15M))
-            Thread.sleep(50)
+            scheduler.advanceUntilIdle()
             schedStatic.verify { runBlocking { Scheduling.enqueueOnce(context, 15L * 60L * 1000L) } }
         }
     }
 
     @Test
     fun `skip does nothing`() {
+        val receiver = DeliveryActionReceiver()
         val context = mock(Context::class.java)
         Mockito.mockStatic(WorkManager::class.java).use { wmStatic ->
             Mockito.mockStatic(Scheduling::class.java).use { schedStatic ->


### PR DESCRIPTION
## Summary
- allow injecting a dispatcher into DeliveryActionReceiver
- replace Thread.sleep with TestCoroutineScheduler in DeliveryActionReceiverTest
- add kotlinx-coroutines-test dependency for new test utilities

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bde34149a8832985d49e517a71c1a6