### PR TITLE
Tag immediate delivery work

### DIFF
--- a/app/src/main/java/de/moosfett/notificationbundler/receivers/DeliveryActionReceiver.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/receivers/DeliveryActionReceiver.kt
@@ -21,7 +21,9 @@ class DeliveryActionReceiver @JvmOverloads constructor(
         when (intent.action) {
             ACTION_DELIVER_NOW -> {
                 // Enqueue an immediate run
-                val req = OneTimeWorkRequestBuilder<DeliveryWorker>().build()
+                val req = OneTimeWorkRequestBuilder<DeliveryWorker>()
+                    .addTag("delivery")
+                    .build()
                 WorkManager.getInstance(context).enqueueUniqueWork(
                     "delivery",
                     ExistingWorkPolicy.KEEP,


### PR DESCRIPTION
## Summary
- tag immediate delivery work with "delivery" for consistency with scheduled runs

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bde6f372e083299424330e1236263e