### PR TITLE
Handle DeliveryWorker retries correctly

### DIFF
--- a/app/src/main/java/de/moosfett/notificationbundler/work/DeliveryWorker.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/work/DeliveryWorker.kt
@@ -15,8 +15,7 @@ class DeliveryWorker(appContext: Context, params: WorkerParameters): CoroutineWo
     private val settings = SettingsStore(appContext)
 
     override suspend fun doWork(): Result {
-        if (runAttemptCount > 0) return Result.success()
-        if (!running.compareAndSet(false, true)) return Result.success()
+        if (!running.compareAndSet(false, true)) return Result.retry()
 
         try {
             // 1) Query pending notifications


### PR DESCRIPTION
## Summary
- Allow DeliveryWorker to process retries by removing early runAttemptCount success check.
- Return `Result.retry()` when another DeliveryWorker instance is running to avoid duplicate concurrent runs.

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bded4af3b88329a108dbcab064c1db