### PR TITLE
Use range query for daily notification count

### DIFF
--- a/app/src/main/java/de/moosfett/notificationbundler/data/db/NotificationDao.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/data/db/NotificationDao.kt
@@ -12,8 +12,8 @@ interface NotificationDao {
     @Query("SELECT * FROM notifications WHERE delivered = 0 AND skipped = 0 AND critical = 0 ORDER BY postTime ASC")
     suspend fun pending(): List<NotificationEntity>
 
-    @Query("SELECT COUNT(*) FROM notifications WHERE date(postTime/1000, 'unixepoch', 'localtime') = date('now', 'localtime')")
-    fun countToday(): Flow<Int>
+    @Query("SELECT COUNT(*) FROM notifications WHERE postTime BETWEEN :start AND :end")
+    fun countToday(start: Long, end: Long): Flow<Int>
 
     @Update
     suspend fun update(e: NotificationEntity)

--- a/app/src/main/java/de/moosfett/notificationbundler/data/repo/NotificationsRepository.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/data/repo/NotificationsRepository.kt
@@ -3,6 +3,9 @@ package de.moosfett.notificationbundler.data.repo
 import android.content.Context
 import de.moosfett.notificationbundler.data.db.AppDatabase
 import de.moosfett.notificationbundler.data.entity.NotificationEntity
+import kotlinx.coroutines.flow.Flow
+import java.time.LocalDate
+import java.time.ZoneId
 
 class NotificationsRepository(private val appContext: Context) {
 
@@ -17,4 +20,11 @@ class NotificationsRepository(private val appContext: Context) {
     suspend fun deleteOlderThan(threshold: Long) = db.notifications().deleteOlderThan(threshold)
 
     suspend fun seenPackages(): List<String> = db.notifications().seenPackages()
+
+    fun countToday(): Flow<Int> {
+        val zone = ZoneId.systemDefault()
+        val start = LocalDate.now(zone).atStartOfDay(zone).toInstant().toEpochMilli()
+        val end = start + 24L * 60L * 60L * 1000L - 1
+        return db.notifications().countToday(start, end)
+    }
 }


### PR DESCRIPTION
## Summary
- Replace date-based count query with a `postTime` range query
- Compute start/end of current day before calling the DAO

## Testing
- `gradle test` *(fails: SDK location not found)*
- `sqlite3` plan shows index usage for `postTime` range query

------
https://chatgpt.com/codex/tasks/task_e_68bdefdf16848329a58e0d114ed30857