### PR TITLE
Remove outdated notification listener uses-permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,8 +5,6 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
-    <!-- Required for NotificationListenerService -->
-    <uses-permission android:name="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE" />
 
     <application
         android:name=".NotificationBundlerApp"


### PR DESCRIPTION
## Summary
- remove BIND_NOTIFICATION_LISTENER_SERVICE uses-permission from manifest

## Testing
- `./gradlew test` *(fails: No such file or directory)*
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf66ab88083298eab57da7d311778