### PR TITLE
Simplify coroutine verification in DeliveryActionReceiverTest

### DIFF
--- a/app/src/test/java/de/moosfett/notificationbundler/receivers/DeliveryActionReceiverTest.kt
+++ b/app/src/test/java/de/moosfett/notificationbundler/receivers/DeliveryActionReceiverTest.kt
@@ -44,7 +44,7 @@ class DeliveryActionReceiverTest {
         Mockito.mockStatic(Scheduling::class.java).use { schedStatic ->
             receiver.onReceive(context, Intent(DeliveryActionReceiver.ACTION_SNOOZE_15M))
             scheduler.advanceUntilIdle()
-            schedStatic.verify { runBlocking { Scheduling.enqueueOnce(context, 15L * 60L * 1000L) } }
+            schedStatic.verify { Scheduling.enqueueOnce(context, 15L * 60L * 1000L) }
         }
     }
 


### PR DESCRIPTION
## Summary
- Remove unnecessary `runBlocking` wrapper when verifying static call to `Scheduling.enqueueOnce`
- Keep use of test scheduler to advance coroutines before verification

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf8518e688329912c9a3d6d6db54b