### PR TITLE
Remove unused foreground service permissions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,9 +2,6 @@
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 
     <application
         android:name=".NotificationBundlerApp"


### PR DESCRIPTION
## Summary
- Remove unused foreground service permissions from manifest

## Testing
- `gradle lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfac1421083299715902c6e9f7bc9