### PR TITLE
Restrict DeliveryActionReceiver broadcasts

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -52,7 +52,7 @@
         <receiver
             android:name=".receivers.DeliveryActionReceiver"
             android:enabled="true"
-            android:exported="true" />
+            android:exported="false" />
 
     </application>
 </manifest>


### PR DESCRIPTION
## Summary
- mark DeliveryActionReceiver as non-exported to prevent outside broadcasts

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be0cfd3aac832982651a687e22a2be