### PR TITLE
Replace existing delivery work on immediate action

### DIFF
--- a/app/src/main/java/de/moosfett/notificationbundler/receivers/DeliveryActionReceiver.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/receivers/DeliveryActionReceiver.kt
@@ -20,13 +20,13 @@ class DeliveryActionReceiver @JvmOverloads constructor(
     override fun onReceive(context: Context, intent: Intent) {
         when (intent.action) {
             ACTION_DELIVER_NOW -> {
-                // Enqueue an immediate run
+                // Enqueue an immediate run, replacing any pending work
                 val req = OneTimeWorkRequestBuilder<DeliveryWorker>()
                     .addTag("delivery")
                     .build()
                 WorkManager.getInstance(context).enqueueUniqueWork(
                     "delivery",
-                    ExistingWorkPolicy.KEEP,
+                    ExistingWorkPolicy.REPLACE,
                     req
                 )
             }


### PR DESCRIPTION
## Summary
- ensure "deliver now" replaces any pending work by using `ExistingWorkPolicy.REPLACE`

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be0d0777748329a1edea7826b863fa