### PR TITLE
Order filter rules by id

### DIFF
--- a/app/src/main/java/de/moosfett/notificationbundler/data/db/FiltersDao.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/data/db/FiltersDao.kt
@@ -6,10 +6,10 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface FiltersDao {
-    @Query("SELECT * FROM filter_rules")
+    @Query("SELECT * FROM filter_rules ORDER BY id")
     suspend fun all(): List<FilterRuleEntity>
 
-    @Query("SELECT * FROM filter_rules")
+    @Query("SELECT * FROM filter_rules ORDER BY id")
     fun observeAll(): Flow<List<FilterRuleEntity>>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/app/src/test/java/de/moosfett/notificationbundler/RuleMatchTest.kt
+++ b/app/src/test/java/de/moosfett/notificationbundler/RuleMatchTest.kt
@@ -2,6 +2,8 @@ package de.moosfett.notificationbundler
 
 import de.moosfett.notificationbundler.data.entity.FilterRuleEntity
 import de.moosfett.notificationbundler.data.entity.NotificationEntity
+import de.moosfett.notificationbundler.service.NotificationCollectorService
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -16,5 +18,26 @@ class RuleMatchTest {
         )
         val ok = (rule.keyword ?: "") in (n.title ?: "")
         assertTrue(ok)
+    }
+
+    @Test
+    fun firstMatchingRuleWins() {
+        val rules = listOf(
+            FilterRuleEntity(id = 1, keyword = "ALARM", isExcluded = true),
+            FilterRuleEntity(id = 2, keyword = "ALARM", isCritical = true)
+        )
+        val n = NotificationEntity(
+            key = null, packageName = "pkg", channelId = null, category = null,
+            title = "ALARM ausgelöst", text = "Motion", postTime = 0,
+            groupKey = null, isOngoing = false, importance = null, extrasJson = null
+        )
+        val service = NotificationCollectorService()
+        val method = NotificationCollectorService::class.java.getDeclaredMethod(
+            "matchRule", List::class.java, NotificationEntity::class.java
+        )
+        method.isAccessible = true
+        val match = method.invoke(service, rules, n) as FilterRuleEntity?
+        assertEquals(1L, match?.id)
+        assertTrue(match?.isExcluded == true)
     }
 }


### PR DESCRIPTION
## Summary
- return filter rules ordered by id so matching is deterministic
- verify rule precedence with a new unit test

## Testing
- `gradle test` *(fails: Failed to find Build Tools revision 34.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68be0d0b6bdc8329bf91a3a3839534fc