### PR TITLE
Add Kotlin Compose compiler plugin

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
   id("com.android.application")
   id("org.jetbrains.kotlin.android")
+  id("org.jetbrains.kotlin.plugin.compose")
   id("com.google.dagger.hilt.android")
   id("com.google.devtools.ksp")
 }
@@ -41,9 +42,6 @@ android {
   buildFeatures {
     compose = true
     buildConfig = true
-  }
-  composeOptions {
-    kotlinCompilerExtensionVersion = "1.5.14"
   }
   packaging {
     resources {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
   id("com.android.application") version "8.4.1" apply false
   id("org.jetbrains.kotlin.android") version "2.0.0" apply false
+  id("org.jetbrains.kotlin.plugin.compose") version "2.0.0" apply false
   id("com.google.dagger.hilt.android") version "2.51.1" apply false
   id("com.google.devtools.ksp") version "2.0.0-1.0.21" apply false
 }


### PR DESCRIPTION
## Summary
- declare the Kotlin Compose compiler plugin in the top-level Gradle build
- apply the Compose compiler plugin to the app module and remove obsolete `composeOptions`

## Testing
- `gradle build` *(fails: Plugin [id: 'org.jetbrains.kotlin.plugin.compose', version: '2.0.0', apply: false] was not found in any of the following sources)*

------
https://chatgpt.com/codex/tasks/task_e_68be5bd9dfdc8329991abc5e9e3ca548