### PR TITLE
docs: document bundled notification actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Notification Bundler (Android, Kotlin, Compose)
 
-**Summary (EN):** The app collects incoming notifications, stores them locally (Room), and delivers them bundled at user‑defined times (WorkManager). Critical messages can be forwarded immediately. All user‑visible text is German (strings.xml); code and comments are in English.
+**Summary (EN):** The app collects incoming notifications, stores them locally (Room), and delivers them bundled at user‑defined times (WorkManager). Critical messages can be forwarded immediately; bundled summaries offer actions to deliver now, snooze 15 minutes, or skip. All user‑visible text is German (strings.xml); code and comments are in English.
 
 ## Build
 - Android Studio Hedgehog / Iguana or newer
@@ -15,18 +15,17 @@ Open → start `app` as Run Configuration (grant permissions).
 - `settings/SettingsStore` – DataStore (schedules, retention).
 - `work/DeliveryWorker`, `work/Scheduling` – bundling & scheduling (WorkManager).
 - `notifications/Notifier` – channel setup + summary/critical paths.
-- `receivers/*` – BOOT_COMPLETED, TIMEZONE_CHANGED, actions.
+- `receivers/*` – BOOT_COMPLETED, TIMEZONE_CHANGED, actions (Deliver/Snooze/Skip).
 - `ui/*` – minimal Compose screens.
 
 ## TODO / Next Steps
 - Full UI for schedule/filter editor.
-- Wire action intents in `Notifier` (Deliver/Snooze/Skip).
 - Expand unit tests (filter engine, retention).
 - Refine Hilt integration for worker/service.
 
 ---
 
-**Kurzfassung (DE):** App sammelt eingehende Benachrichtigungen, speichert sie lokal (Room) und liefert sie zu benutzerdefinierten Zeiten gebündelt aus (WorkManager). Kritische Nachrichten können sofort durchgereicht werden. Alle sichtbaren Texte sind Deutsch (strings.xml); Code & Kommentare sind Englisch.
+**Kurzfassung (DE):** App sammelt eingehende Benachrichtigungen, speichert sie lokal (Room) und liefert sie zu benutzerdefinierten Zeiten gebündelt aus (WorkManager). Kritische Nachrichten können sofort durchgereicht werden; die Zusammenfassung bietet Aktionen für Sofortzustellung, 15‑Minuten-Snooze oder Überspringen. Alle sichtbaren Texte sind Deutsch (strings.xml); Code & Kommentare sind Englisch.
 
 ## Build
 - Android Studio Hedgehog / Iguana oder neuer
@@ -41,11 +40,10 @@ Open → start `app` as Run Configuration (grant permissions).
 - `settings/SettingsStore` – DataStore (Zeiten, Retention).
 - `work/DeliveryWorker`, `work/Scheduling` – Bündelung & Planung (WorkManager).
 - `notifications/Notifier` – Kanal-Setup + Summary/Kritisch.
-- `receivers/*` – BOOT_COMPLETED, TIMEZONE_CHANGED, Aktionen.
+- `receivers/*` – BOOT_COMPLETED, TIMEZONE_CHANGED, Aktionen (Sofort/Snooze/Überspringen).
 - `ui/*` – Compose-Screens (minimal).
 
 ## TODO / Next Steps
 - Volle UI für Schedule/Filter-Editor.
-- Action-Intents in `Notifier` (Deliver/Snooze/Skip) verdrahten.
 - Unit-Tests ausbauen (Filter Engine, Retention).
 - Hilt-Integration für Worker/Service verfeinern.


### PR DESCRIPTION
## Summary
- mention deliver-now, snooze, and skip actions in README
- remove outdated TODO entry about wiring notification actions

## Testing
- `gradle test --console=plain` *(fails: Plugin [id: 'org.jetbrains.kotlin.plugin.compose', version: '2.0.0', apply: false] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be5d61f8d08329b1313df7447b6933