### PR TITLE
Promote agent briefs into AGENTS.md files

### DIFF
--- a/app/src/main/AGENTS.md
+++ b/app/src/main/AGENTS.md
@@ -1,4 +1,4 @@
-# Agent Brief — Manifest & Permissions
+# AGENTS
 
 Goal: Keep the manifest minimal but correct. Ensure NotificationListenerService is declared with proper permission; ask for POST_NOTIFICATIONS at runtime on 33+; reschedule on BOOT_COMPLETED and TIMEZONE_CHANGED.
 

--- a/app/src/main/java/de/moosfett/notificationbundler/data/AGENTS.md
+++ b/app/src/main/java/de/moosfett/notificationbundler/data/AGENTS.md
@@ -1,4 +1,4 @@
-# Agent Brief — Data Layer (Room + DataStore)
+# AGENTS
 
 Goal: Expand entities and DAOs; add indices on `postTime`, `packageName`. Provide query helpers for "pending" windows and retention. Use KSP (no KAPT).
 

--- a/app/src/main/java/de/moosfett/notificationbundler/filters/AGENTS.md
+++ b/app/src/main/java/de/moosfett/notificationbundler/filters/AGENTS.md
@@ -1,4 +1,4 @@
-# Agent Brief — Filter Engine
+# AGENTS
 
 Goal: Simple, readable rule matching by package/channel/keyword with two actions: mark critical (passthrough) or exclude.
 

--- a/app/src/main/java/de/moosfett/notificationbundler/ui/AGENTS.md
+++ b/app/src/main/java/de/moosfett/notificationbundler/ui/AGENTS.md
@@ -1,4 +1,4 @@
-# Agent Brief — App Shell & Navigation
+# AGENTS
 
 Goal: Maintain a clean, single-activity Compose app with bottom navigation across six screens (Dashboard, Preview, Schedules, Filters, Log, Settings). Keep strings in German via resources; keep code/comments in English. Avoid business logic here; connect to ViewModels later.
 

--- a/app/src/main/java/de/moosfett/notificationbundler/work/AGENTS.md
+++ b/app/src/main/java/de/moosfett/notificationbundler/work/AGENTS.md
@@ -1,4 +1,4 @@
-# Agent Brief — WorkManager & Scheduling
+# AGENTS
 
 Goal: Deterministic scheduling based on a list of HH:mm (local time). After each run, compute the next occurrence and enqueue one-off work (REPLACE policy).
 


### PR DESCRIPTION
## Summary
- convert agent brief markdown files into scoped AGENTS.md files for UI, data, filters, manifest, and work packages
- remove obsolete `agents` directory

## Testing
- `gradle test` *(fails: plugin 'org.jetbrains.kotlin.plugin.compose' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be63fcc2d483299f6f8aa5ef043a1a