### PR TITLE
chore: bump version to 0.1.1 and migrate TODOs into AGENTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,7 @@ Open → start `app` as Run Configuration (grant permissions).
 - `receivers/*` – BOOT_COMPLETED, TIMEZONE_CHANGED, actions (Deliver/Snooze/Skip).
 - `ui/*` – minimal Compose screens.
 
-## TODO / Next Steps
-- Full UI for schedule/filter editor.
-- Expand unit tests (filter engine, retention).
-- Refine Hilt integration for worker/service.
-
 ---
-
 **Kurzfassung (DE):** App sammelt eingehende Benachrichtigungen, speichert sie lokal (Room) und liefert sie zu benutzerdefinierten Zeiten gebündelt aus (WorkManager). Kritische Nachrichten können sofort durchgereicht werden; die Zusammenfassung bietet Aktionen für Sofortzustellung, 15‑Minuten-Snooze oder Überspringen. Alle sichtbaren Texte sind Deutsch (strings.xml); Code & Kommentare sind Englisch.
 
 ## Build
@@ -42,8 +36,3 @@ Open → start `app` as Run Configuration (grant permissions).
 - `notifications/Notifier` – Kanal-Setup + Summary/Kritisch.
 - `receivers/*` – BOOT_COMPLETED, TIMEZONE_CHANGED, Aktionen (Sofort/Snooze/Überspringen).
 - `ui/*` – Compose-Screens (minimal).
-
-## TODO / Next Steps
-- Volle UI für Schedule/Filter-Editor.
-- Unit-Tests ausbauen (Filter Engine, Retention).
-- Hilt-Integration für Worker/Service verfeinern.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
     applicationId = "de.moosfett.notificationbundler"
     minSdk = 26
     targetSdk = 35
-    versionCode = 1
-    versionName = "0.1.0"
+    versionCode = 2
+    versionName = "0.1.1"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     vectorDrawables { useSupportLibrary = true }

--- a/app/src/main/AGENTS.md
+++ b/app/src/main/AGENTS.md
@@ -5,3 +5,4 @@ Goal: Keep the manifest minimal but correct. Ensure NotificationListenerService 
 Tasks:
 - Add `QUERY_ALL_PACKAGES` only if strictly needed.
 - Add explicit exported flags as required by targetSdk 35.
+- Refine Hilt integration for NotificationCollectorService.

--- a/app/src/main/java/de/moosfett/notificationbundler/data/AGENTS.md
+++ b/app/src/main/java/de/moosfett/notificationbundler/data/AGENTS.md
@@ -6,3 +6,4 @@ Tasks:
 - Add migrations (v2+).
 - Introduce DeliveryLog entity (timestamp, counts).
 - Optimize queries for large volumes.
+- Expand unit tests for retention logic.

--- a/app/src/main/java/de/moosfett/notificationbundler/filters/AGENTS.md
+++ b/app/src/main/java/de/moosfett/notificationbundler/filters/AGENTS.md
@@ -6,3 +6,4 @@ Tasks:
 - Implement LIKE/regex matching and per-app defaults.
 - Add quick-add rules from a notification item in Preview.
 - Persist evaluation results for auditing.
+- Expand unit tests for filter engine.

--- a/app/src/main/java/de/moosfett/notificationbundler/ui/AGENTS.md
+++ b/app/src/main/java/de/moosfett/notificationbundler/ui/AGENTS.md
@@ -6,3 +6,4 @@ Tasks:
 - Flesh out each screen with state & events.
 - Add a preview UI to show the next batch.
 - Provide a package picker (labels via PackageManager) for filters.
+- Build full schedule and filter editor UI.

--- a/app/src/main/java/de/moosfett/notificationbundler/work/AGENTS.md
+++ b/app/src/main/java/de/moosfett/notificationbundler/work/AGENTS.md
@@ -6,3 +6,4 @@ Tasks:
 - Wire action buttons: deliver now, snooze 15m, skip.
 - Respect `includeOngoing` and `includeLowImportance` toggles.
 - Add idempotency (run guard) to DeliveryWorker.
+- Refine Hilt integration for DeliveryWorker.


### PR DESCRIPTION
## Summary
- bump version to 0.1.1
- move README TODO notes into scoped AGENTS files
- clean README of TODO/Next Steps sections

## Testing
- `gradle test` *(fails: Plugin [id: 'org.jetbrains.kotlin.plugin.compose', version: '2.0.0', apply: false] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be6889345c8329aaec167004bcfde9