### PR TITLE
Add Material Design library dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -66,6 +66,9 @@ dependencies {
   implementation("androidx.core:core-ktx:1.13.1")
   implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.2")
 
+  // Material Design components
+  implementation("com.google.android.material:material:1.12.0")
+
   // Hilt (no hilt-work wiring yet to keep it simple)
   implementation("com.google.dagger:hilt-android:2.51.1")
   ksp("com.google.dagger:hilt-compiler:2.51.1")


### PR DESCRIPTION
## Summary
- include the Material Design components library in app module

## Testing
- `gradle build` *(fails: Plugin [id: 'org.jetbrains.kotlin.plugin.compose', version: '2.0.0'] not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be6eaf49848329ab127d7007a54930