### PR TITLE
chore: update material library

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,7 +67,7 @@ dependencies {
   implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.2")
 
   // Material Design components
-  implementation("com.google.android.material:material:1.12.0")
+  implementation("com.google.android.material:material:1.13.0")
 
   // Hilt (no hilt-work wiring yet to keep it simple)
   implementation("com.google.dagger:hilt-android:2.51.1")


### PR DESCRIPTION
## Summary
- upgrade Material Components to stable 1.13.0

## Testing
- `gradle test` *(fails: Plugin [id: 'org.jetbrains.kotlin.plugin.compose', version: '2.0.0'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be7041cd3883298618c69e44746ccb