### PR TITLE
Implement preview screen UI

### DIFF
--- a/app/src/main/java/de/moosfett/notificationbundler/ui/screens/PreviewScreen.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/ui/screens/PreviewScreen.kt
@@ -1,23 +1,86 @@
 package de.moosfett.notificationbundler.ui.screens
 
 import androidx.compose.foundation.layout.*
-import androidx.compose.material3.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import de.moosfett.notificationbundler.R
 
+/**
+ * Preview screen showing the next bundled notification batch.
+ * State and events are provided externally (ViewModel).
+ */
 @Composable
-fun PreviewScreen() {
+fun PreviewScreen(
+    state: PreviewState = PreviewState(),
+    onEvent: (PreviewEvent) -> Unit = {},
+) {
     Column(
-        modifier = Modifier.fillMaxSize().padding(16.dp),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.Top,
     ) {
-        Text(text = stringResource(id = R.string.preview), style = MaterialTheme.typography.headlineSmall)
-        Spacer(Modifier.height(12.dp))
-        Text("This screen is intentionally minimal. Add logic and state later.")
+        Text(
+            text = stringResource(id = R.string.preview),
+            style = MaterialTheme.typography.headlineSmall
+        )
+        Spacer(Modifier.height(24.dp))
+
+        if (state.lines.isEmpty()) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(text = stringResource(id = R.string.no_pending_notifications))
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier.weight(1f, fill = true)
+            ) {
+                items(state.lines) { line ->
+                    Text(text = line, style = MaterialTheme.typography.bodyMedium)
+                    Spacer(Modifier.height(8.dp))
+                }
+            }
+            Spacer(Modifier.height(24.dp))
+            Row(
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Button(onClick = { onEvent(PreviewEvent.DeliverNow) }) {
+                    Text(text = stringResource(id = R.string.deliver_now))
+                }
+                Button(onClick = { onEvent(PreviewEvent.Snooze15m) }) {
+                    Text(text = stringResource(id = R.string.snooze_15m))
+                }
+                Button(onClick = { onEvent(PreviewEvent.Skip) }) {
+                    Text(text = stringResource(id = R.string.skip))
+                }
+            }
+        }
     }
 }
+
+/** UI state for the preview screen. */
+data class PreviewState(
+    val lines: List<String> = emptyList(),
+)
+
+/**
+ * User intents originating from the preview screen.
+ * ViewModels can react to these and perform work.
+ */
+sealed interface PreviewEvent {
+    data object DeliverNow : PreviewEvent
+    data object Snooze15m : PreviewEvent
+    data object Skip : PreviewEvent
+}
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,4 +18,5 @@
     <string name="notifications_not_allowed">Benachrichtigungen sind nicht erlaubt.</string>
     <string name="grant_permission">Berechtigung erteilen</string>
     <string name="status_counters">Heute: %1$d erfasst • %2$d in Warteschlange • %3$d kritisch</string>
+    <string name="no_pending_notifications">Keine Benachrichtigungen in Warteschlange</string>
 </resources>


### PR DESCRIPTION
## Summary
- show upcoming bundled notifications in preview screen
- add actions to deliver, snooze, or skip from preview
- add German string for empty preview state

## Testing
- `gradle test` *(fails: com.android.application plugin 8.13.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be7e1c22408329adfd9edfef1998aa