### PR TITLE
Add schedule management UI with time picker

### DIFF
--- a/app/src/main/java/de/moosfett/notificationbundler/schedules/SchedulesViewModel.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/schedules/SchedulesViewModel.kt
@@ -1,0 +1,55 @@
+package de.moosfett.notificationbundler.schedules
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import de.moosfett.notificationbundler.settings.SettingsStore
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * Holds the configured delivery times.
+ */
+data class SchedulesUiState(
+    val times: List<String> = emptyList()
+)
+
+class SchedulesViewModel(private val store: SettingsStore) : ViewModel() {
+
+    private val _state = MutableStateFlow(SchedulesUiState())
+    val state: StateFlow<SchedulesUiState> = _state
+
+    init {
+        viewModelScope.launch {
+            _state.value = SchedulesUiState(store.getTimes())
+        }
+    }
+
+    fun addTime(hour: Int, minute: Int) {
+        val time = String.format("%02d:%02d", hour, minute)
+        viewModelScope.launch {
+            store.addTime(time)
+            _state.update { it.copy(times = store.getTimes()) }
+        }
+    }
+
+    fun removeTime(time: String) {
+        viewModelScope.launch {
+            store.removeTime(time)
+            _state.update { it.copy(times = store.getTimes()) }
+        }
+    }
+}
+
+class SchedulesViewModelFactory(private val context: Context) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(SchedulesViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return SchedulesViewModel(SettingsStore(context.applicationContext)) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/app/src/main/java/de/moosfett/notificationbundler/settings/SettingsStore.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/settings/SettingsStore.kt
@@ -76,6 +76,14 @@ class SettingsStore(private val context: Context) {
         }
     }
 
+    suspend fun removeTime(time: String) {
+        context.dataStore.edit { prefs ->
+            val s = prefs[Keys.TIMES]?.toMutableSet() ?: mutableSetOf()
+            s.remove(time)
+            prefs[Keys.TIMES] = s
+        }
+    }
+
     suspend fun retentionDays(): Int =
         context.dataStore.data.map { it[Keys.RETENTION_DAYS] ?: 30 }.first()
 

--- a/app/src/main/java/de/moosfett/notificationbundler/ui/screens/SchedulesScreen.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/ui/screens/SchedulesScreen.kt
@@ -1,23 +1,93 @@
 package de.moosfett.notificationbundler.ui.screens
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.material3.TimePicker
+import androidx.compose.material3.rememberTimePickerState
 import de.moosfett.notificationbundler.R
+import de.moosfett.notificationbundler.schedules.SchedulesViewModel
+import de.moosfett.notificationbundler.schedules.SchedulesViewModelFactory
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SchedulesScreen() {
-    Column(
-        modifier = Modifier.fillMaxSize().padding(16.dp),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Text(text = stringResource(id = R.string.schedules), style = MaterialTheme.typography.headlineSmall)
-        Spacer(Modifier.height(12.dp))
-        Text("This screen is intentionally minimal. Add logic and state later.")
+    val vm: SchedulesViewModel = viewModel(factory = SchedulesViewModelFactory(LocalContext.current))
+    val state by vm.state.collectAsState()
+
+    var showPicker by remember { mutableStateOf(false) }
+    val pickerState = rememberTimePickerState()
+
+    Scaffold(
+        floatingActionButton = {
+            FloatingActionButton(onClick = { showPicker = true }) {
+                Icon(Icons.Filled.Add, contentDescription = stringResource(R.string.add_time))
+            }
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .padding(16.dp)
+        ) {
+            Text(
+                text = stringResource(id = R.string.schedules),
+                style = MaterialTheme.typography.headlineSmall
+            )
+            Spacer(Modifier.height(12.dp))
+            if (state.times.isEmpty()) {
+                Text(text = stringResource(R.string.no_times))
+            } else {
+                LazyColumn {
+                    items(state.times) { time ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Text(time)
+                            IconButton(onClick = { vm.removeTime(time) }) {
+                                Icon(
+                                    Icons.Filled.Delete,
+                                    contentDescription = stringResource(R.string.remove_time)
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (showPicker) {
+        AlertDialog(
+            onDismissRequest = { showPicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    showPicker = false
+                    vm.addTime(pickerState.hour, pickerState.minute)
+                }) { Text(stringResource(R.string.ok)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { showPicker = false }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            },
+            text = { TimePicker(state = pickerState) }
+        )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,4 +19,9 @@
     <string name="grant_permission">Berechtigung erteilen</string>
     <string name="status_counters">Heute: %1$d erfasst • %2$d in Warteschlange • %3$d kritisch</string>
     <string name="no_pending_notifications">Keine Benachrichtigungen in Warteschlange</string>
+    <string name="add_time">Zeit hinzufügen</string>
+    <string name="remove_time">Entfernen</string>
+    <string name="no_times">Keine Zeiten definiert</string>
+    <string name="ok">OK</string>
+    <string name="cancel">Abbrechen</string>
 </resources>

--- a/app/src/test/java/de/moosfett/notificationbundler/settings/SettingsStoreTest.kt
+++ b/app/src/test/java/de/moosfett/notificationbundler/settings/SettingsStoreTest.kt
@@ -1,6 +1,7 @@
 package de.moosfett.notificationbundler.settings
 
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -23,5 +24,14 @@ class SettingsStoreTest {
     @Test(expected = IllegalArgumentException::class)
     fun `addTime rejects invalid time`() = runBlocking {
         store.addTime("99:99")
+    }
+
+    @Test
+    fun `removeTime deletes time`() = runBlocking {
+        val t = "08:00"
+        store.addTime(t)
+        store.removeTime(t)
+        val times = store.getTimes()
+        assertFalse(times.contains(t))
     }
 }


### PR DESCRIPTION
## Summary
- build ViewModel and screen to manage delivery times
- support adding and removing times via a Material 3 time picker
- extend SettingsStore with removal API and tests

## Testing
- `gradle test` *(fails: Plugin [id: 'com.android.application', version: '8.13.0', apply: false] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be806d18a88329b7d936b117329d23