### PR TITLE
Use KEEP policy for immediate delivery

### DIFF
--- a/app/src/main/java/de/moosfett/notificationbundler/receivers/DeliveryActionReceiver.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/receivers/DeliveryActionReceiver.kt
@@ -20,13 +20,13 @@ class DeliveryActionReceiver @JvmOverloads constructor(
     override fun onReceive(context: Context, intent: Intent) {
         when (intent.action) {
             ACTION_DELIVER_NOW -> {
-                // Enqueue an immediate run, replacing any pending work
+                // Enqueue an immediate run, keeping any existing work
                 val req = OneTimeWorkRequestBuilder<DeliveryWorker>()
                     .addTag("delivery")
                     .build()
                 WorkManager.getInstance(context).enqueueUniqueWork(
                     "delivery",
-                    ExistingWorkPolicy.REPLACE,
+                    ExistingWorkPolicy.KEEP,
                     req
                 )
             }


### PR DESCRIPTION
## Summary
- Use `ExistingWorkPolicy.KEEP` when handling `ACTION_DELIVER_NOW`
- Ensure the receiver comment reflects non-replacement behavior

## Testing
- ⚠️ `gradle test` *(failed: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c05a514f54832997200aba63c6790b