### PR TITLE
Restrict boot/timezone receivers

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,7 +34,7 @@
         <receiver
             android:name=".receivers.BootCompletedReceiver"
             android:enabled="true"
-            android:exported="true">
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
             </intent-filter>
@@ -43,7 +43,7 @@
         <receiver
             android:name=".receivers.TimezoneChangedReceiver"
             android:enabled="true"
-            android:exported="true">
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.TIMEZONE_CHANGED" />
             </intent-filter>

--- a/app/src/test/java/de/moosfett/notificationbundler/receivers/BootCompletedReceiverTest.kt
+++ b/app/src/test/java/de/moosfett/notificationbundler/receivers/BootCompletedReceiverTest.kt
@@ -1,0 +1,33 @@
+package de.moosfett.notificationbundler.receivers
+
+import android.content.Context
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import de.moosfett.notificationbundler.settings.SettingsStore
+import de.moosfett.notificationbundler.work.Scheduling
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyLong
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mockito
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class BootCompletedReceiverTest {
+
+    @Test
+    fun `boot completed schedules next delivery`() {
+        val receiver = BootCompletedReceiver()
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        Mockito.mockConstruction(SettingsStore::class.java) { mock, _ ->
+            Mockito.`when`(mock.getTimes()).thenReturn(emptyList())
+        }.use {
+            Mockito.mockStatic(Scheduling::class.java).use { schedStatic ->
+                receiver.onReceive(context, Intent(Intent.ACTION_BOOT_COMPLETED))
+                Thread.sleep(50)
+                schedStatic.verify { Scheduling.enqueueOnce(eq(context), anyLong()) }
+            }
+        }
+    }
+}

--- a/app/src/test/java/de/moosfett/notificationbundler/receivers/TimezoneChangedReceiverTest.kt
+++ b/app/src/test/java/de/moosfett/notificationbundler/receivers/TimezoneChangedReceiverTest.kt
@@ -1,0 +1,33 @@
+package de.moosfett.notificationbundler.receivers
+
+import android.content.Context
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import de.moosfett.notificationbundler.settings.SettingsStore
+import de.moosfett.notificationbundler.work.Scheduling
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyLong
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mockito
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class TimezoneChangedReceiverTest {
+
+    @Test
+    fun `timezone changed schedules next delivery`() {
+        val receiver = TimezoneChangedReceiver()
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        Mockito.mockConstruction(SettingsStore::class.java) { mock, _ ->
+            Mockito.`when`(mock.getTimes()).thenReturn(emptyList())
+        }.use {
+            Mockito.mockStatic(Scheduling::class.java).use { schedStatic ->
+                receiver.onReceive(context, Intent(Intent.ACTION_TIMEZONE_CHANGED))
+                Thread.sleep(50)
+                schedStatic.verify { Scheduling.enqueueOnce(eq(context), anyLong()) }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- mark BootCompletedReceiver and TimezoneChangedReceiver as non-exported in manifest
- add unit tests confirming boot and timezone receivers schedule next delivery when broadcasted

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c05a516f008329b1376520d5c16b67