### PR TITLE
Cache include toggles for notification filtering

### DIFF
--- a/app/src/main/java/de/moosfett/notificationbundler/settings/SettingsStore.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/settings/SettingsStore.kt
@@ -9,6 +9,7 @@ import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import java.time.LocalTime
@@ -97,15 +98,19 @@ class SettingsStore @Inject constructor(
         context.dataStore.edit { it[Keys.RETENTION_DAYS] = days }
     }
 
-    suspend fun includeOngoing(): Boolean =
-        context.dataStore.data.map { it[Keys.INCLUDE_ONGOING] ?: true }.first()
+    val includeOngoingFlow: Flow<Boolean> =
+        context.dataStore.data.map { it[Keys.INCLUDE_ONGOING] ?: true }
+
+    suspend fun includeOngoing(): Boolean = includeOngoingFlow.first()
 
     suspend fun setIncludeOngoing(include: Boolean) {
         context.dataStore.edit { it[Keys.INCLUDE_ONGOING] = include }
     }
 
-    suspend fun includeLowImportance(): Boolean =
-        context.dataStore.data.map { it[Keys.INCLUDE_LOW_IMPORTANCE] ?: true }.first()
+    val includeLowImportanceFlow: Flow<Boolean> =
+        context.dataStore.data.map { it[Keys.INCLUDE_LOW_IMPORTANCE] ?: true }
+
+    suspend fun includeLowImportance(): Boolean = includeLowImportanceFlow.first()
 
     suspend fun setIncludeLowImportance(include: Boolean) {
         context.dataStore.edit { it[Keys.INCLUDE_LOW_IMPORTANCE] = include }

--- a/app/src/test/java/de/moosfett/notificationbundler/service/NotificationCollectorServiceTest.kt
+++ b/app/src/test/java/de/moosfett/notificationbundler/service/NotificationCollectorServiceTest.kt
@@ -43,11 +43,15 @@ class NotificationCollectorServiceTest {
 
     private lateinit var service: NotificationCollectorService
     private val notificationManager = mock(NotificationManager::class.java)
+    private val includeOngoingFlow = MutableStateFlow(true)
+    private val includeLowImportanceFlow = MutableStateFlow(true)
 
     @Before
     fun setup() {
         hiltRule.inject()
         Mockito.`when`(filtersRepo.observeAll()).thenReturn(MutableStateFlow(emptyList()))
+        Mockito.`when`(settings.includeOngoingFlow).thenReturn(includeOngoingFlow)
+        Mockito.`when`(settings.includeLowImportanceFlow).thenReturn(includeLowImportanceFlow)
         service = NotificationCollectorService()
         setField("scope", CoroutineScope(Dispatchers.Unconfined))
         service.onCreate()
@@ -56,8 +60,8 @@ class NotificationCollectorServiceTest {
 
     @Test
     fun ongoingNotificationSkippedWhenDisabled() = runBlocking {
-        Mockito.`when`(settings.includeOngoing()).thenReturn(false)
-        Mockito.`when`(settings.includeLowImportance()).thenReturn(true)
+        includeOngoingFlow.value = false
+        includeLowImportanceFlow.value = true
 
         val sbn = mockSbn(isOngoing = true, importance = NotificationManager.IMPORTANCE_DEFAULT)
 
@@ -68,8 +72,8 @@ class NotificationCollectorServiceTest {
 
     @Test
     fun lowImportanceNotificationSkippedWhenDisabled() = runBlocking {
-        Mockito.`when`(settings.includeOngoing()).thenReturn(true)
-        Mockito.`when`(settings.includeLowImportance()).thenReturn(false)
+        includeOngoingFlow.value = true
+        includeLowImportanceFlow.value = false
 
         val sbn = mockSbn(isOngoing = false, importance = NotificationManager.IMPORTANCE_LOW)
 


### PR DESCRIPTION
## Summary
- expose include flags as flows in SettingsStore
- cache includeOngoing and includeLowImportance in NotificationCollectorService
- adjust tests to use cached flag flows

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c05e2216d0832981cbe79c661352b7