### PR TITLE
Add dashboard and preview view models

### DIFF
--- a/app/src/main/java/de/moosfett/notificationbundler/data/db/NotificationDao.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/data/db/NotificationDao.kt
@@ -15,11 +15,20 @@ interface NotificationDao {
     @Query("SELECT COUNT(*) FROM notifications WHERE postTime BETWEEN :start AND :end")
     fun countToday(start: Long, end: Long): Flow<Int>
 
+    @Query("SELECT COUNT(*) FROM notifications WHERE delivered = 0 AND skipped = 0 AND critical = 0")
+    fun pendingCount(): Flow<Int>
+
+    @Query("SELECT COUNT(*) FROM notifications WHERE critical = 1 AND delivered = 0")
+    fun criticalCount(): Flow<Int>
+
     @Update
     suspend fun update(e: NotificationEntity)
 
     @Query("UPDATE notifications SET delivered=1 WHERE id IN (:ids)")
     suspend fun markDelivered(ids: List<Long>)
+
+    @Query("UPDATE notifications SET skipped=1 WHERE id IN (:ids)")
+    suspend fun markSkipped(ids: List<Long>)
 
     @Query("DELETE FROM notifications WHERE postTime < :threshold")
     suspend fun deleteOlderThan(threshold: Long)

--- a/app/src/main/java/de/moosfett/notificationbundler/data/repo/NotificationsRepository.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/data/repo/NotificationsRepository.kt
@@ -21,7 +21,13 @@ class NotificationsRepository @Inject constructor(
 
     suspend fun pending(): List<NotificationEntity> = db.notifications().pending()
 
+    fun pendingCount(): Flow<Int> = db.notifications().pendingCount()
+
+    fun criticalCount(): Flow<Int> = db.notifications().criticalCount()
+
     suspend fun markDelivered(ids: List<Long>) = db.notifications().markDelivered(ids)
+
+    suspend fun markSkipped(ids: List<Long>) = db.notifications().markSkipped(ids)
 
     suspend fun deleteOlderThan(threshold: Long) = db.notifications().deleteOlderThan(threshold)
 

--- a/app/src/main/java/de/moosfett/notificationbundler/ui/DashboardViewModel.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/ui/DashboardViewModel.kt
@@ -1,0 +1,106 @@
+package de.moosfett.notificationbundler.ui
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.work.WorkManager
+import de.moosfett.notificationbundler.data.repo.NotificationsRepository
+import de.moosfett.notificationbundler.settings.SettingsStore
+import de.moosfett.notificationbundler.ui.screens.DashboardEvent
+import de.moosfett.notificationbundler.ui.screens.DashboardState
+import de.moosfett.notificationbundler.work.Scheduling
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+/** ViewModel backing the dashboard screen. */
+class DashboardViewModel(
+    private val repo: NotificationsRepository,
+    private val settings: SettingsStore,
+    private val workManager: WorkManager,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(DashboardState())
+    val state: StateFlow<DashboardState> = _state
+
+    private val formatter = DateTimeFormatter.ofPattern("HH:mm")
+
+    init {
+        viewModelScope.launch {
+            combine(
+                repo.countToday(),
+                repo.pendingCount(),
+                repo.criticalCount(),
+            ) { today, pending, critical -> Triple(today, pending, critical) }
+                .collect { (today, pending, critical) ->
+                    _state.update {
+                        it.copy(
+                            todayCount = today,
+                            pendingCount = pending,
+                            criticalCount = critical,
+                        )
+                    }
+                }
+        }
+
+        viewModelScope.launch { updateFromSettings(schedule = false) }
+    }
+
+    fun onEvent(event: DashboardEvent) {
+        when (event) {
+            DashboardEvent.DeliverNow -> scheduleOnce(0)
+            DashboardEvent.Snooze15m -> scheduleOnce(15L * 60L * 1000L)
+            DashboardEvent.Skip -> viewModelScope.launch {
+                val ids = repo.pending().map { it.id }
+                if (ids.isNotEmpty()) repo.markSkipped(ids)
+                updateFromSettings(schedule = true)
+            }
+            DashboardEvent.PostNotificationsGranted -> viewModelScope.launch {
+                updateFromSettings(schedule = true)
+            }
+        }
+    }
+
+    private fun scheduleOnce(delay: Long) {
+        viewModelScope.launch {
+            Scheduling.enqueueOnce(workManager, delay)
+            val time = Instant.ofEpochMilli(System.currentTimeMillis() + delay)
+                .atZone(ZoneId.systemDefault())
+                .format(formatter)
+            _state.update { it.copy(nextDeliveryTime = time) }
+        }
+    }
+
+    private suspend fun updateFromSettings(schedule: Boolean) {
+        val times = settings.getTimes()
+        val now = ZonedDateTime.now(ZoneId.systemDefault())
+        val next = Scheduling.nextRun(now, times)
+        val delay = (next.toInstant().toEpochMilli() - System.currentTimeMillis()).coerceAtLeast(0)
+        if (schedule) Scheduling.enqueueOnce(workManager, delay)
+        val formatted = next.toLocalTime().format(formatter)
+        _state.update { it.copy(nextDeliveryTime = formatted) }
+    }
+}
+
+/** Factory to create a [DashboardViewModel] with context backed dependencies. */
+class DashboardViewModelFactory(private val context: Context) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(DashboardViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return DashboardViewModel(
+                NotificationsRepository(context.applicationContext),
+                SettingsStore(context.applicationContext),
+                WorkManager.getInstance(context.applicationContext),
+            ) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}
+

--- a/app/src/main/java/de/moosfett/notificationbundler/ui/PreviewViewModel.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/ui/PreviewViewModel.kt
@@ -1,0 +1,82 @@
+package de.moosfett.notificationbundler.ui
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.work.WorkManager
+import de.moosfett.notificationbundler.data.repo.NotificationsRepository
+import de.moosfett.notificationbundler.settings.SettingsStore
+import de.moosfett.notificationbundler.ui.screens.PreviewEvent
+import de.moosfett.notificationbundler.ui.screens.PreviewState
+import de.moosfett.notificationbundler.work.Scheduling
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+/** ViewModel backing the preview screen. */
+class PreviewViewModel(
+    private val repo: NotificationsRepository,
+    private val settings: SettingsStore,
+    private val workManager: WorkManager,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(PreviewState())
+    val state: StateFlow<PreviewState> = _state
+
+    init {
+        viewModelScope.launch { refresh() }
+    }
+
+    fun onEvent(event: PreviewEvent) {
+        when (event) {
+            PreviewEvent.DeliverNow -> scheduleOnce(0)
+            PreviewEvent.Snooze15m -> scheduleOnce(15L * 60L * 1000L)
+            PreviewEvent.Skip -> viewModelScope.launch {
+                val ids = repo.pending().map { it.id }
+                if (ids.isNotEmpty()) repo.markSkipped(ids)
+                scheduleFromSettings()
+                refresh()
+            }
+        }
+    }
+
+    private fun scheduleOnce(delay: Long) {
+        viewModelScope.launch { Scheduling.enqueueOnce(workManager, delay) }
+    }
+
+    private suspend fun scheduleFromSettings() {
+        val times = settings.getTimes()
+        val now = ZonedDateTime.now(ZoneId.systemDefault())
+        val next = Scheduling.nextRun(now, times)
+        val delay = (next.toInstant().toEpochMilli() - System.currentTimeMillis()).coerceAtLeast(0)
+        Scheduling.enqueueOnce(workManager, delay)
+    }
+
+    private suspend fun refresh() {
+        val lines = repo.pending()
+            .groupBy { it.packageName }
+            .map { (pkg, list) -> "${list.size} × $pkg" }
+            .sorted()
+        _state.update { it.copy(lines = lines) }
+    }
+}
+
+/** Factory to create a [PreviewViewModel] with context backed dependencies. */
+class PreviewViewModelFactory(private val context: Context) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(PreviewViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return PreviewViewModel(
+                NotificationsRepository(context.applicationContext),
+                SettingsStore(context.applicationContext),
+                WorkManager.getInstance(context.applicationContext),
+            ) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}
+

--- a/app/src/main/java/de/moosfett/notificationbundler/ui/nav/AppNav.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/ui/nav/AppNav.kt
@@ -4,13 +4,20 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import androidx.lifecycle.viewmodel.compose.viewModel
+import de.moosfett.notificationbundler.ui.DashboardViewModel
+import de.moosfett.notificationbundler.ui.DashboardViewModelFactory
+import de.moosfett.notificationbundler.ui.PreviewViewModel
+import de.moosfett.notificationbundler.ui.PreviewViewModelFactory
 import de.moosfett.notificationbundler.ui.screens.*
 
 sealed class Dest(val route: String, val labelRes: Int) {
@@ -45,8 +52,18 @@ fun AppNav() {
         }
     ) { padding ->
         NavHost(navController = nav, startDestination = Dest.Dashboard.route, modifier = Modifier.padding(padding)) {
-            composable(Dest.Dashboard.route) { DashboardScreen() }
-            composable(Dest.Preview.route) { PreviewScreen() }
+            composable(Dest.Dashboard.route) {
+                val context = LocalContext.current
+                val vm: DashboardViewModel = viewModel(factory = DashboardViewModelFactory(context))
+                val state by vm.state.collectAsState()
+                DashboardScreen(state = state, onEvent = vm::onEvent)
+            }
+            composable(Dest.Preview.route) {
+                val context = LocalContext.current
+                val vm: PreviewViewModel = viewModel(factory = PreviewViewModelFactory(context))
+                val state by vm.state.collectAsState()
+                PreviewScreen(state = state, onEvent = vm::onEvent)
+            }
             composable(Dest.Schedules.route) { SchedulesScreen() }
             composable(Dest.Filters.route) { FiltersScreen() }
             composable(Dest.Log.route) { LogScreen() }


### PR DESCRIPTION
## Summary
- add DAO and repository helpers for pending and critical counts and skipping
- implement DashboardViewModel and PreviewViewModel using viewModelScope and Scheduling
- wire Dashboard and Preview screens to these view models in AppNav

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c063331e848329b152f29e5a5ff315