### PR TITLE
Add pattern rule types and log filter evaluations

### DIFF
--- a/app/src/main/java/de/moosfett/notificationbundler/data/db/FilterEvaluationsDao.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/data/db/FilterEvaluationsDao.kt
@@ -1,0 +1,12 @@
+package de.moosfett.notificationbundler.data.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import de.moosfett.notificationbundler.data.entity.FilterEvaluationEntity
+
+@Dao
+interface FilterEvaluationsDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(e: FilterEvaluationEntity)
+}

--- a/app/src/main/java/de/moosfett/notificationbundler/data/db/FiltersDao.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/data/db/FiltersDao.kt
@@ -15,6 +15,9 @@ interface FiltersDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsert(rule: FilterRuleEntity): Long
 
+    @Query("SELECT * FROM filter_rules WHERE packageName = :pkg AND isDefault = 1 LIMIT 1")
+    suspend fun defaultForPackage(pkg: String): FilterRuleEntity?
+
     @Delete
     suspend fun delete(rule: FilterRuleEntity)
 }

--- a/app/src/main/java/de/moosfett/notificationbundler/data/entity/FilterEvaluationEntity.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/data/entity/FilterEvaluationEntity.kt
@@ -1,0 +1,18 @@
+package de.moosfett.notificationbundler.data.entity
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "filter_evaluations",
+    indices = [Index("postTime"), Index("packageName")]
+)
+data class FilterEvaluationEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val notificationKey: String?,
+    val packageName: String,
+    val postTime: Long,
+    val ruleId: Long?,
+    val decision: String
+)

--- a/app/src/main/java/de/moosfett/notificationbundler/data/entity/FilterRuleEntity.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/data/entity/FilterRuleEntity.kt
@@ -3,12 +3,16 @@ package de.moosfett.notificationbundler.data.entity
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
+enum class PatternType { EXACT, LIKE, REGEX }
+
 @Entity(tableName = "filter_rules")
 data class FilterRuleEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,
     val packageName: String? = null,
     val channelId: String? = null,
     val keyword: String? = null,
+    val patternType: PatternType = PatternType.EXACT,
     val isCritical: Boolean = false,
-    val isExcluded: Boolean = false
+    val isExcluded: Boolean = false,
+    val isDefault: Boolean = false
 )

--- a/app/src/main/java/de/moosfett/notificationbundler/data/repo/FiltersRepository.kt
+++ b/app/src/main/java/de/moosfett/notificationbundler/data/repo/FiltersRepository.kt
@@ -3,6 +3,7 @@ package de.moosfett.notificationbundler.data.repo
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import de.moosfett.notificationbundler.data.db.AppDatabase
+import de.moosfett.notificationbundler.data.entity.FilterEvaluationEntity
 import de.moosfett.notificationbundler.data.entity.FilterRuleEntity
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
@@ -19,6 +20,12 @@ class FiltersRepository @Inject constructor(
     fun observeAll(): Flow<List<FilterRuleEntity>> = db.filters().observeAll()
 
     suspend fun upsert(rule: FilterRuleEntity) = db.filters().upsert(rule)
+
+    suspend fun defaultForPackage(pkg: String): FilterRuleEntity? =
+        db.filters().defaultForPackage(pkg)
+
+    suspend fun logEvaluation(e: FilterEvaluationEntity) =
+        db.filterEvaluations().insert(e)
 
     suspend fun delete(rule: FilterRuleEntity) = db.filters().delete(rule)
 }


### PR DESCRIPTION
## Summary
- support LIKE and regex rule types with per-package defaults
- record filter evaluation decisions in new `filter_evaluations` table
- expand rule matcher and tests for regex and default cases

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c064bd940c8329a1c7c9cf34445223